### PR TITLE
Sped up process_frame()

### DIFF
--- a/CMT.py
+++ b/CMT.py
@@ -252,9 +252,6 @@ class CMT(object):
 
 				classes = self.database_classes
 
-				#Sort in descending order
-				sorted_conf = argsort(combined)[::-1] #reverse
-
 				#Get best and second best index
 				bestInd = matches[0].trainIdx
 				secondBestInd = matches[1].trainIdx


### PR DESCRIPTION
I sped up process_frame() by doing the following:
-- Find only the top 2 nearest matches with the feature_database (instead of computing all distances)
-- Precompute neighbors for selected_features if necessary

On some data that I'm working with I went from 41ms per frame (using the master) to 27ms per frame (using this fork).
