### PR TITLE
Fixed running on python-opencv 2.4.8

### DIFF
--- a/util.py
+++ b/util.py
@@ -142,10 +142,10 @@ def track(im_prev, im_gray, keypoints, THR_FB=20):
 		pts = keypoints[:, None, :2].astype(np.float32)
 
 		# Calculate forward optical flow for prev_location
-		nextPts, status, _ = cv2.calcOpticalFlowPyrLK(im_prev, im_gray, pts)
+		nextPts, status, _ = cv2.calcOpticalFlowPyrLK(im_prev, im_gray, pts, None)
 
 		# Calculate backward optical flow for prev_location
-		pts_back, _, _ = cv2.calcOpticalFlowPyrLK(im_gray, im_prev, nextPts)
+		pts_back, _, _ = cv2.calcOpticalFlowPyrLK(im_gray, im_prev, nextPts, None)
 
 		# Remove singleton dimension
 		pts_back = squeeze_pts(pts_back)


### PR DESCRIPTION
When trying to run CMT on an opencv 2.4.8 installation, it complains
about missing parameters on cv2.calcOpticalFlowPyrLK. This was "fixed" by
passing None on both calls. I have no idea if it breaks other versions of
opencv/python-opencv

Signed-off-by: Luiz Carlos Cavalcanti ext-luiz-carlos.cavalcanti@microsoft.com
